### PR TITLE
Minor update for running examples, this will work with python3.x not …

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ file, while the second inside `enginedemo.py`. You can simply run them
 using
 
 ```
-python joindemo.py
+python3 joindemo.py
 ```
 and
 ```
-python enginedemo.py
+python3 enginedemo.py
 ```
 
 After running for a certain amount of time, both demo resets and


### PR DESCRIPTION
…python2.x

Hi Micheal,

I followed the instructions and try to execute the example with the commands provided. However, I faced issues with imports as below.

'''
 safras@Safrass-MacBook-Pro examples % python  joindemo.py
Traceback (most recent call last):
  File "joindemo.py", line 22, in <module>
    from utils import add_platooning_vehicle, communicate, get_distance, \
  File "/Users/safras/src/plexe-pyapi/examples/utils.py", line 30, in <module>
    from plexe import POS_X, POS_Y, ENGINE_MODEL_REALISTIC   #test chnage path
ImportError: No module named plexe
'''
there were some sources on how to fix this issue, I started changing the code but it seems never-ending.... then I realised this is due to python version mismatch. 

my version for python as below. 

'''
safras@Safrass-MacBook-Pro examples % python -V            
Python 2.7.16
'''
this seems previously install. then I tried to upgrade the python version but it says its already upgraded to the latest

' Warning: python 3.8.5 already installed '

Apparently to use this version we need to call python 3 as "python3 <filename.py>" as python will work both versions without conflicts.

Finally,  I tried the examples with python3  joindemo.py, python3 enginedemo.py and its works nicely. 

Therefore, I am kindly requesting to simply update the example execution script as I amended in README file. this will save lot of time for someone like me. ;)

Thank you.

Regards,
Safras